### PR TITLE
add TemplateDataSource, for creating templates of type datasource.  Add

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -662,6 +662,90 @@ class Template(object):
             'tagValuesQuery': self.tagValuesQuery,
         }
 
+@attr.s
+class TemplateDataSource(object):
+    """TemplateDataSource create a new 'variable' for the dashboard
+    whose values are the datasource names in the Grafana DB.
+
+        :param default: the default value for the variable
+        :param name: the variable's name
+        :param query: the type of datasource to query, e.g. 'prometheus'
+        :param label: the variable's human label
+        :param regex: a regex to filter the datasource names by
+    """
+
+    default = attr.ib()
+    name = attr.ib()
+    query = attr.ib()
+    label = attr.ib(default='')
+    regex = attr.ib(default='')
+
+    def to_json_data(self):
+        return {
+            'current': {
+                'text': self.default,
+                'value': self.default,
+                'tags': [],
+            },
+            'hide': 0,
+            'label': self.label,
+            'name': self.name,
+            'options': [],
+            'query': self.query,
+            'refresh': 1,
+            'regex': self.regex,
+            'sort': 1,
+            'type': 'datasource',
+        }
+
+@attr.s
+class TemplateNoQuery(object):
+    """TemplateNoQuery create a new 'variable' for the dashboard whose
+    values are predefined.
+
+        :param default: the default value for the variable
+        :param name: the variable's name
+        :param type: the variable's type, 'custom' or 'interval'
+        :param label: the variable's human label
+        :param values: the list of values the variable may have
+
+    Only valid for type 'custom':
+        :param multi: allow multiple selections
+        :param includeAll: allow 'All' selection, with allValue of '.+'
+    """
+    default = attr.ib()
+    name = attr.ib()
+    type = attr.ib()
+    label = attr.ib(default='')
+    values = attr.ib(default=attr.Factory(list))
+    multi = attr.ib(default=False)
+    includeAll = attr.ib(default=False)
+
+    def to_json_data(self):
+        tmpl = {
+            'current': {
+                'text': self.default,
+                'value': self.default,
+            },
+            'hide': 0,
+            'label': self.label,
+            'name': self.name,
+            'options': [{'selected': i==self.default, 'text': i, 'value': i} for i in self.values],
+            'query': ','.join(self.values),
+            'type': self.type,
+            'includeAll': False,
+            'multi': False,
+        }
+
+        if self.type == 'interval':
+            tmpl['auto'] = False
+        elif self.type == 'custom':
+            tmpl['multi'] = self.multi
+            if self.includeAll:
+                tmpl['allValue'] = '.+'
+                tmpl['includeAll'] = True
+        return tmpl
+
 
 @attr.s
 class Templating(object):


### PR DESCRIPTION
TemplateNoQuery, for creating templates of types interval and custom;
these templates do no queries, they have hardcoded lists of values.

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
